### PR TITLE
chore: rename sidecar to port

### DIFF
--- a/alumiini-git/Cargo.toml
+++ b/alumiini-git/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alumiini-git"
 version = "0.1.0"
 edition = "2021"
-description = "Git operations sidecar for ALUMIINI"
+description = "Git operations port for ALUMIINI"
 license = "Apache-2.0"
 
 [dependencies]

--- a/alumiini-git/src/main.rs
+++ b/alumiini-git/src/main.rs
@@ -1,4 +1,4 @@
-//! alumiini-git: Git operations sidecar for ALUMIINI
+//! alumiini-git: Git operations port for ALUMIINI
 //!
 //! Communicates via length-prefixed msgpack over stdin/stdout.
 //! Protocol: 4-byte big-endian length + msgpack payload


### PR DESCRIPTION
## Summary

- Rename \"sidecar\" to \"port\" in Rust crate description and docs

## Why

\"Sidecar\" is K8s terminology (container alongside main container). This is actually an **Erlang Port** - a subprocess communicating via stdin/stdout.

## Changes

- `alumiini-git/Cargo.toml` - description
- `alumiini-git/src/main.rs` - doc comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)