### PR TITLE
feat: add head operation to git port

### DIFF
--- a/nopea-git/src/main.rs
+++ b/nopea-git/src/main.rs
@@ -44,8 +44,7 @@ fn read_request<R: Read>(reader: &mut R) -> Result<Request, io::Error> {
     reader.read_exact(&mut payload)?;
 
     // Deserialize msgpack
-    rmp_serde::from_slice(&payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    rmp_serde::from_slice(&payload).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
 fn write_response<W: Write>(writer: &mut W, response: &Response) -> Result<(), io::Error> {

--- a/nopea-git/src/protocol.rs
+++ b/nopea-git/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Protocol definitions for nopea-git
 
-use serde::{Deserialize, Serialize, ser::SerializeMap};
+use serde::{ser::SerializeMap, Deserialize, Serialize};
 
 use crate::git::CommitInfo;
 


### PR DESCRIPTION
## Summary
- Add `head` operation to get commit metadata (sha, author, email, message, timestamp)
- Enables status reporting: "synced to abc123 by @yair: fix deployment"
- Foundation for rollback feature (know what commits we deployed)

## Changes
- **Rust**: `CommitInfo` struct + `head()` function + protocol handling
- **Elixir**: `Git.head/1` + `commit_info` type
- **Tests**: Unit + integration tests

## Test plan
- [x] Rust tests pass (`cargo test`)
- [x] Elixir tests pass (`mix test`)
- [x] Integration test creates git repo and verifies commit info

🤖 Generated with [Claude Code](https://claude.com/claude-code)