### PR TITLE
feat: add K8s health and readiness probes

### DIFF
--- a/lib/nopea/webhook/router.ex
+++ b/lib/nopea/webhook/router.ex
@@ -120,9 +120,11 @@ defmodule Nopea.Webhook.Router do
 
       pid ->
         try do
-          state = GenServer.call(pid, :get_state, 1000)
-          watching = state.watch_ref != nil
-          repo_count = map_size(state.repos)
+          # 2s timeout - K8s probes typically have 1-10s timeouts
+          state = GenServer.call(pid, :get_state, 2000)
+          # Controller returns Map.from_struct, so use map access
+          watching = state[:watch_ref] != nil
+          repo_count = map_size(state[:repos] || %{})
 
           if watching do
             {:ok, %{watching: true, repo_count: repo_count}}


### PR DESCRIPTION
## Summary

- Add `/health` liveness probe that checks if Cache and ULID processes are alive
- Add `/ready` readiness probe that checks if Controller is actively watching CRDs
- Both return 503 with diagnostic details when unhealthy/not ready

## Endpoints

| Endpoint | Purpose | Checks |
|----------|---------|--------|
| `GET /health` | Liveness | Cache up, ULID up |
| `GET /ready` | Readiness | Controller watching CRDs |

## Response Examples

```json
// GET /health (healthy)
{"status": "healthy", "checks": {"cache": "up", "ulid": "up"}}

// GET /ready (ready)
{"ready": true, "watching": true, "repos": 3}

// GET /ready (not ready)
{"ready": false, "watching": false, "reason": "not_watching"}
```

## Test plan

- [x] Health returns 200 when processes are up
- [x] Health returns 503 when Cache is down
- [x] Ready returns 200 when Controller is watching
- [x] Ready returns 503 when Controller not watching
- [x] Ready returns 503 when Controller not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)