### PR TITLE
ci: run on arc-arm64 self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-
 
       - uses: azure/setup-helm@v4
-        with:
-          version: "v3.16.0"
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   ci:
     name: CI (Sykli)
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +42,7 @@ jobs:
 
   status:
     name: CI Status
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: [ci]
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
 
+      - uses: azure/setup-helm@v4
+        with:
+          version: "v3.16.0"
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-
 
       - uses: azure/setup-helm@v4
+        with:
+          version: "v3.19.0"   # newest v3: knows platformHooks; v4 forces plugin verification
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
 


### PR DESCRIPTION
Org-wide move off GitHub-hosted runners onto the org's free ARC pool (context: false-systems/false-infra#5). This PR's own CI executes on arc-arm64 — green checks prove the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)